### PR TITLE
Context Menu

### DIFF
--- a/Chrome/eventPage.js
+++ b/Chrome/eventPage.js
@@ -10,28 +10,43 @@ chrome.browserAction.onClicked.addListener(function(tab) {
       chrome.windows.getAll({ populate: true}, function(windows) {
         _.each(windows, function(win) {
           _.each(win.tabs, function(tab) {
-            if (tab.active) return;
-            if (tab.status != 'complete') return;
-            if (!tab.url.match(/^https?:\/\//)) return;
-
-            window.setTimeout(function() {
-
-              var pageInfo = {
-                url: tab.url,
-                title: tab.title,
-                favIconUrl: tab.favIconUrl
-              };
-
-              var pageHtml = html.replace(/\{\/\*pageInfoObject\*\/\}/, JSON.stringify(pageInfo));
-              var dataURL = 'data:text/html;charset=utf-8,' + encodeURIComponent(pageHtml);
-              chrome.tabs.update(tab.id, {url: dataURL});
-            }, c * 100);
+			if (tab.active) return;
+			if (tab.status != 'complete') return;
+			if (!tab.url.match(/^https?:\/\//)) return;
+            sleepTab(html, tab, c * 100);
             c++;
-
           });
         })
       });
     }
+  };
+  xmlHttp.send(null);
+});
+function sleepTab(html, tab, timeout) {
+	window.setTimeout(function() {
+	  var pageInfo = {
+		url: tab.url,
+		title: tab.title,
+		favIconUrl: tab.favIconUrl
+	  };
+	  var pageHtml = html.replace(/\{\/\*pageInfoObject\*\/\}/, JSON.stringify(pageInfo));
+	  var dataURL = 'data:text/html;charset=utf-8,' + encodeURIComponent(pageHtml);
+	  chrome.tabs.update(tab.id, {url: dataURL});
+	}, timeout);
+}
+chrome.contextMenus.create({
+	id : "SleepTab" ,
+	title : "Hibernate This Page" ,
+	contexts : ["page"]
+});
+chrome.contextMenus.onClicked.addListener(function(info, tab) {
+  var xmlHttp = new XMLHttpRequest();
+  xmlHttp.open('GET', chrome.extension.getURL('lib/hibernationPage/index.html'), true);
+  xmlHttp.onreadystatechange = function () {
+	if (xmlHttp.readyState == 4) {
+	  var html = xmlHttp.responseText;
+	  sleepTab(html, tab, 100);
+	}
   };
   xmlHttp.send(null);
 });

--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -3,7 +3,10 @@
   "name": "Tab Hibernation",
   "description": "Sends your inactive tabs to sleep",
   "version": "0.1.3",
-  "permissions": ["tabs"],
+  "permissions": [
+    "tabs",
+    "contextMenus"
+  ],
   "browser_action": {
     "default_icon": {
       "19": "icon19.png",


### PR DESCRIPTION
This adds a "Sleep This Page" action to the context menu. Comes in handy when you're planning on leaving a page open for revisiting later, but don't want to sleep all tabs.
